### PR TITLE
Inputタグのフォントサイズ変更

### DIFF
--- a/src/app/(protected)/timer/_components/FormItem.tsx
+++ b/src/app/(protected)/timer/_components/FormItem.tsx
@@ -36,7 +36,7 @@ export default function FormItem({
           min={min}
           max={max}
           id={id}
-          className="block w-20 rounded-lg border border-gray-300 bg-white/75 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+          className="block w-20 rounded-lg border border-gray-300 bg-white/75 p-2.5 text-gray-900 focus:border-blue-500 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
           disabled={disabled}
           {...register(id)}
         />

--- a/src/app/(public)/(auth)/_components/AuthFormItem.tsx
+++ b/src/app/(public)/(auth)/_components/AuthFormItem.tsx
@@ -32,7 +32,7 @@ export default function AuthFormItem({
       <input
         type={type}
         id={id}
-        className="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+        className="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-gray-900 focus:border-blue-500 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
         placeholder={placeholder}
         disabled={isSubmitting}
         required

--- a/src/app/(public)/(auth)/_components/PasswordInput.tsx
+++ b/src/app/(public)/(auth)/_components/PasswordInput.tsx
@@ -65,7 +65,7 @@ export default function PasswordInput({
           type={showPassword ? "text" : "password"}
           id="password"
           placeholder="••••••••"
-          className="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+          className="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-gray-900 focus:border-blue-500 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
           disabled={isSubmitting}
           {...register("password")}
         />


### PR DESCRIPTION
フォントサイズが16px未満になっており、スマホ入力時に拡大されてしまう問題を解消しました。