### PR TITLE
タイマー設定フォームのリセットボタンのタイプを「reset」から「button」に変更

### DIFF
--- a/src/app/(protected)/timer/_components/TimerSettingsForm.tsx
+++ b/src/app/(protected)/timer/_components/TimerSettingsForm.tsx
@@ -137,7 +137,7 @@ export default function TimerSettingsForm({
             <div className="flex justify-between">
               <Button
                 variant="outline"
-                type="reset"
+                type="button"
                 onClick={timerSettingsReset}
                 disabled={isSubmitting}
                 className="!bg-transparent backdrop-blur-none"


### PR DESCRIPTION
resetタイプにしていたことにより、リセットボタンクリックにて値が空欄になってしまっていたため。