### PR TITLE
ブラウザタブ非アクティブ時のトークン期限切れに対応。セッション自動更新とリトライ機能を実装してDB保存を確実化。

### DIFF
--- a/src/app/(protected)/timer/_components/PomodoroCompletionModal.tsx
+++ b/src/app/(protected)/timer/_components/PomodoroCompletionModal.tsx
@@ -29,14 +29,20 @@ export const PomodoroCompletionModal: React.FC<Props> = ({
 
   const onSubmitPomodoroLogModal = async (displayInTimeline: boolean) => {
     setIsPomodoroCompletionModalOpen(false);
-    await createPomodoroLog({
-      completedCount: storedSettings.cycles,
-      completedTime: storedSettings.focusTime,
-      displayInTimeline,
-      categoryIds,
-      token: token ?? "",
-    });
-    Confetti();
+    try {
+      await createPomodoroLog({
+        completedCount: storedSettings.cycles,
+        completedTime: storedSettings.focusTime,
+        displayInTimeline,
+        categoryIds,
+        token: token ?? "",
+      });
+      Confetti();
+    } catch (error) {
+      console.error("ポモドーロログの保存に失敗:", error);
+      // エラー時は通知のみで、Confettiは実行しない
+      alert("データ保存に失敗しました。インターネット接続を確認してください。");
+    }
   };
 
   // プレビュー用のログデータ

--- a/src/app/(protected)/timer/_components/PomodoroCompletionModal.tsx
+++ b/src/app/(protected)/timer/_components/PomodoroCompletionModal.tsx
@@ -7,6 +7,7 @@ import { createPomodoroLog } from "../_lib/createPomodoroLog";
 import { TimerSettings } from "@/app/_config/timerConfig";
 import { Confetti } from "./Confetti";
 import { PomodoroLogType } from "@/app/_types/pomodoro";
+import { toast } from "react-toastify";
 
 interface Props {
   storedSettings: TimerSettings;
@@ -41,7 +42,9 @@ export const PomodoroCompletionModal: React.FC<Props> = ({
     } catch (error) {
       console.error("ポモドーロログの保存に失敗:", error);
       // エラー時は通知のみで、Confettiは実行しない
-      alert("データ保存に失敗しました。インターネット接続を確認してください。");
+      toast.error(
+        "データ保存に失敗しました。インターネット接続を確認してください。"
+      );
     }
   };
 

--- a/src/app/(protected)/timer/_lib/createPomodoroLog.test.ts
+++ b/src/app/(protected)/timer/_lib/createPomodoroLog.test.ts
@@ -1,0 +1,323 @@
+import { createPomodoroLog } from "./createPomodoroLog";
+import { fetcher } from "@/app/_utils/fetcher";
+import { supabase } from "@/app/_utils/supabase";
+
+// fetcherとsupabaseをモック化
+jest.mock("@/app/_utils/fetcher");
+jest.mock("@/app/_utils/supabase", () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn(),
+    },
+  },
+}));
+
+const mockFetcher = fetcher as jest.MockedFunction<typeof fetcher>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockSupabase = supabase as any;
+
+describe("createPomodoroLog", () => {
+  const mockParams = {
+    completedCount: 4,
+    completedTime: 25,
+    displayInTimeline: true,
+    categoryIds: ["category-1", "category-2"],
+    token: "test-token-123",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // console.errorとconsole.logをモック化してテスト出力をクリーンに保つ
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("正常系", () => {
+    it("正常にポモドーロログを作成できる", async () => {
+      // Arrange
+      const mockResponse = {
+        status: "success",
+        message: "ポモドーロログを作成しました",
+        data: { id: "log-123" },
+      };
+
+      mockFetcher.mockResolvedValue(mockResponse);
+
+      // Act
+      await createPomodoroLog(mockParams);
+
+      // Assert: fetcherが正しいパラメータで呼ばれることを確認
+      expect(mockFetcher).toHaveBeenCalledWith({
+        apiPath: "/api/pomodoro",
+        method: "POST",
+        body: {
+          completedCount: 4,
+          completedTime: 25,
+          displayInTimeline: true,
+          categoryIds: ["category-1", "category-2"],
+        },
+        token: "test-token-123",
+      });
+      expect(mockFetcher).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("異常系 - リトライなし", () => {
+    it("ネットワークエラー時は即座に例外を投げる", async () => {
+      // Arrange
+      const networkError = new Error("Network error");
+      mockFetcher.mockRejectedValue(networkError);
+
+      // Act & Assert
+      await expect(createPomodoroLog(mockParams)).rejects.toThrow(
+        "Network error"
+      );
+
+      expect(mockFetcher).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledWith(
+        "ポモドーロログの作成に失敗しました",
+        networkError
+      );
+    });
+
+    it("バリデーションエラー時は即座に例外を投げる", async () => {
+      // Arrange
+      const validationError = new Error("Validation failed");
+      mockFetcher.mockRejectedValue(validationError);
+
+      // Act & Assert
+      await expect(createPomodoroLog(mockParams)).rejects.toThrow(
+        "Validation failed"
+      );
+
+      expect(mockFetcher).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("異常系 - 認証エラーリトライ", () => {
+    it("認証エラー時にリトライして成功する", async () => {
+      // Arrange
+      const authError = new Error("認証に失敗しました");
+      const mockNewSession = {
+        access_token: "new-token-456",
+        user: { id: "user-123" },
+      };
+
+      // 1回目は認証エラー、2回目は成功
+      mockFetcher
+        .mockRejectedValueOnce(authError)
+        .mockResolvedValueOnce({ status: "success" });
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: mockNewSession },
+        error: null,
+      });
+
+      // Act
+      await createPomodoroLog(mockParams);
+
+      // Assert: 2回fetcherが呼ばれることを確認
+      expect(mockFetcher).toHaveBeenCalledTimes(2);
+
+      // 1回目の呼び出し（失敗）
+      expect(mockFetcher).toHaveBeenNthCalledWith(1, {
+        apiPath: "/api/pomodoro",
+        method: "POST",
+        body: {
+          completedCount: 4,
+          completedTime: 25,
+          displayInTimeline: true,
+          categoryIds: ["category-1", "category-2"],
+        },
+        token: "test-token-123",
+      });
+
+      // 2回目の呼び出し（成功、新しいトークンを使用）
+      expect(mockFetcher).toHaveBeenNthCalledWith(2, {
+        apiPath: "/api/pomodoro",
+        method: "POST",
+        body: {
+          completedCount: 4,
+          completedTime: 25,
+          displayInTimeline: true,
+          categoryIds: ["category-1", "category-2"],
+        },
+        token: "new-token-456",
+      });
+
+      // 開発環境でのみconsole.logが実行されることを確認
+      if (process.env.NODE_ENV === "development") {
+        expect(console.log).toHaveBeenCalledWith(
+          "認証エラーを検出。セッションを更新してリトライします..."
+        );
+        expect(console.log).toHaveBeenCalledWith(
+          "リトライによりポモドーロログの作成に成功しました"
+        );
+      } else {
+        expect(console.log).not.toHaveBeenCalled();
+      }
+    });
+
+    it("unauthorizedエラー時にリトライして成功する", async () => {
+      // Arrange
+      const authError = new Error("unauthorized access");
+      const mockNewSession = {
+        access_token: "new-token-789",
+        user: { id: "user-456" },
+      };
+
+      mockFetcher
+        .mockRejectedValueOnce(authError)
+        .mockResolvedValueOnce({ status: "success" });
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: mockNewSession },
+        error: null,
+      });
+
+      // Act
+      await createPomodoroLog(mockParams);
+
+      // Assert
+      expect(mockFetcher).toHaveBeenCalledTimes(2);
+      expect(mockFetcher).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          token: "new-token-789",
+        })
+      );
+    });
+
+    it("401エラー時にリトライして成功する", async () => {
+      // Arrange
+      const authError = new Error("401 authentication failed");
+      const mockNewSession = {
+        access_token: "refreshed-token-abc",
+        user: { id: "user-789" },
+      };
+
+      mockFetcher
+        .mockRejectedValueOnce(authError)
+        .mockResolvedValueOnce({ status: "success" });
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: mockNewSession },
+        error: null,
+      });
+
+      // Act
+      await createPomodoroLog(mockParams);
+
+      // Assert
+      expect(mockFetcher).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("異常系 - リトライも失敗", () => {
+    it("セッション更新に失敗した場合", async () => {
+      // Arrange
+      const authError = new Error("認証に失敗しました");
+      mockFetcher.mockRejectedValue(authError);
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: null },
+        error: null,
+      });
+
+      // Act & Assert
+      await expect(createPomodoroLog(mockParams)).rejects.toThrow(
+        "認証エラー: ログインし直してください"
+      );
+
+      expect(mockFetcher).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledWith(
+        "リトライも失敗しました",
+        expect.any(Error)
+      );
+    });
+
+    it("セッション取得時にエラーが発生した場合", async () => {
+      // Arrange
+      const authError = new Error("unauthorized");
+      mockFetcher.mockRejectedValue(authError);
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: null },
+        error: new Error("Session fetch failed"),
+      });
+
+      // Act & Assert
+      await expect(createPomodoroLog(mockParams)).rejects.toThrow(
+        "認証エラー: ログインし直してください"
+      );
+    });
+
+    it("リトライ後も認証エラーが続く場合", async () => {
+      // Arrange
+      const authError = new Error("認証失敗");
+      const retryError = new Error("リトライでも認証失敗");
+
+      mockFetcher
+        .mockRejectedValueOnce(authError)
+        .mockRejectedValueOnce(retryError);
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: { access_token: "valid-token" } },
+        error: null,
+      });
+
+      // Act & Assert
+      await expect(createPomodoroLog(mockParams)).rejects.toThrow(
+        "認証エラー: ログインし直してください"
+      );
+
+      expect(mockFetcher).toHaveBeenCalledTimes(2);
+      expect(console.error).toHaveBeenCalledWith(
+        "リトライも失敗しました",
+        retryError
+      );
+    });
+  });
+
+  describe("境界値テスト", () => {
+    it("空のカテゴリIDでも正常に動作する", async () => {
+      // Arrange
+      const paramsWithEmptyCategories = {
+        ...mockParams,
+        categoryIds: [],
+      };
+
+      mockFetcher.mockResolvedValue({ status: "success" });
+
+      // Act
+      await createPomodoroLog(paramsWithEmptyCategories);
+
+      // Assert
+      expect(mockFetcher).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            categoryIds: [],
+          }),
+        })
+      );
+    });
+
+    it("空のトークンでも正常にエラーハンドリングが動作する", async () => {
+      // Arrange
+      const paramsWithEmptyToken = {
+        ...mockParams,
+        token: "",
+      };
+
+      const authError = new Error("認証が必要です");
+      mockFetcher.mockRejectedValue(authError);
+
+      // Act & Assert
+      await expect(createPomodoroLog(paramsWithEmptyToken)).rejects.toThrow();
+    });
+  });
+});

--- a/src/app/(protected)/timer/_lib/createPomodoroLog.ts
+++ b/src/app/(protected)/timer/_lib/createPomodoroLog.ts
@@ -1,4 +1,5 @@
 import { fetcher } from "@/app/_utils/fetcher";
+import { supabase } from "@/app/_utils/supabase";
 
 interface Props {
   completedCount: number;
@@ -29,6 +30,54 @@ export const createPomodoroLog = async ({
     });
   } catch (error) {
     console.error("ポモドーロログの作成に失敗しました", error);
+
+    // 認証エラーの場合はリトライを試行
+    if (
+      error instanceof Error &&
+      (error.message.includes("認証") ||
+        error.message.includes("unauthorized") ||
+        error.message.includes("401"))
+    ) {
+      try {
+        if (process.env.NODE_ENV === "development") {
+          console.log(
+            "認証エラーを検出。セッションを更新してリトライします..."
+          );
+        }
+
+        // 最新のセッションを取得
+        const {
+          data: { session },
+          error: sessionError,
+        } = await supabase.auth.getSession();
+
+        if (sessionError || !session?.access_token) {
+          throw new Error("セッションの更新に失敗しました");
+        }
+
+        // 新しいトークンでリトライ
+        await fetcher({
+          apiPath: "/api/pomodoro",
+          method: "POST",
+          body: {
+            completedCount,
+            completedTime,
+            displayInTimeline,
+            categoryIds,
+          },
+          token: session.access_token,
+        });
+
+        if (process.env.NODE_ENV === "development") {
+          console.log("リトライによりポモドーロログの作成に成功しました");
+        }
+        return;
+      } catch (retryError) {
+        console.error("リトライも失敗しました", retryError);
+        throw new Error("認証エラー: ログインし直してください");
+      }
+    }
+
     throw error;
   }
 };

--- a/src/app/(protected)/timer/page.tsx
+++ b/src/app/(protected)/timer/page.tsx
@@ -124,13 +124,19 @@ export default function Page() {
       if (postButtonToTimeline) {
         setIsPomodoroCompletionModalOpen(true);
       } else {
-        await createPomodoroLog({
-          completedCount: storedSettings.cycles,
-          completedTime: storedSettings.focusTime,
-          displayInTimeline: false,
-          categoryIds,
-          token: token ?? "",
-        });
+        try {
+          await createPomodoroLog({
+            completedCount: storedSettings.cycles,
+            completedTime: storedSettings.focusTime,
+            displayInTimeline: false,
+            categoryIds,
+            token: token ?? "",
+          });
+          toast.success("ポモドーロが正常に記録されました！");
+        } catch (error) {
+          console.error("ポモドーロログの保存に失敗:", error);
+          toast.error("データ保存に失敗しました。インターネット接続を確認してください。");
+        }
       }
       if (setRandomTime) {
         // ランダムな設定をセット

--- a/src/app/(protected)/timer/page.tsx
+++ b/src/app/(protected)/timer/page.tsx
@@ -125,17 +125,23 @@ export default function Page() {
         setIsPomodoroCompletionModalOpen(true);
       } else {
         try {
+          if (!token) {
+            toast.error("認証情報がありません。再度ログインしてください。");
+            return;
+          }
           await createPomodoroLog({
             completedCount: storedSettings.cycles,
             completedTime: storedSettings.focusTime,
             displayInTimeline: false,
             categoryIds,
-            token: token ?? "",
+            token,
           });
           toast.success("ポモドーロが正常に記録されました！");
         } catch (error) {
           console.error("ポモドーロログの保存に失敗:", error);
-          toast.error("データ保存に失敗しました。インターネット接続を確認してください。");
+          toast.error(
+            "データ保存に失敗しました。インターネット接続を確認してください。"
+          );
         }
       }
       if (setRandomTime) {

--- a/src/app/_hooks/useSupabaseSession.test.ts
+++ b/src/app/_hooks/useSupabaseSession.test.ts
@@ -1,0 +1,342 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useSupabaseSession } from "./useSupabaseSession";
+import { supabase } from "@/app/_utils/supabase";
+import { usePathname } from "next/navigation";
+
+// Next.jsとSupabaseをモック化
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(),
+}));
+
+jest.mock("@/app/_utils/supabase", () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn(),
+      onAuthStateChange: jest.fn(),
+    },
+  },
+}));
+
+const mockUsePathname = usePathname as jest.MockedFunction<typeof usePathname>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockSupabase = supabase as any;
+
+describe("useSupabaseSession", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePathname.mockReturnValue("/test");
+    // console.errorをモック化してテスト出力をクリーンに保つ
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("初期セッション取得", () => {
+    it("セッションが存在する場合、正しく状態を設定する", async () => {
+      // Arrange: モックセッションデータを準備
+      const mockSession = {
+        access_token: "test-token-123",
+        user: { id: "user-123" },
+      };
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: mockSession },
+        error: null,
+      });
+
+      const mockUnsubscribe = jest.fn();
+      mockSupabase.auth.onAuthStateChange.mockReturnValue({
+        data: { subscription: { unsubscribe: mockUnsubscribe } },
+      });
+
+      // Act: フックを実行
+      const { result } = renderHook(() => useSupabaseSession());
+
+      // 初期状態の確認
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.session).toBe(undefined);
+      expect(result.current.token).toBe(null);
+      expect(result.current.error).toBe(null);
+
+      // セッション取得完了まで待機
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Assert: 期待する結果と比較
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.session).toBe(mockSession);
+      expect(result.current.token).toBe("test-token-123");
+      expect(result.current.error).toBe(null);
+    });
+
+    it("セッションが存在しない場合、null状態を設定する", async () => {
+      // Arrange
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: null },
+        error: null,
+      });
+
+      const mockUnsubscribe = jest.fn();
+      mockSupabase.auth.onAuthStateChange.mockReturnValue({
+        data: { subscription: { unsubscribe: mockUnsubscribe } },
+      });
+
+      // Act
+      const { result } = renderHook(() => useSupabaseSession());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Assert
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.session).toBe(null);
+      expect(result.current.token).toBe(null);
+      expect(result.current.error).toBe(null);
+    });
+
+    it("セッション取得時にSupabaseエラーが発生した場合、エラー状態を設定する", async () => {
+      // Arrange
+      const mockError = new Error("Supabase session error");
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: null },
+        error: mockError,
+      });
+
+      const mockUnsubscribe = jest.fn();
+      mockSupabase.auth.onAuthStateChange.mockReturnValue({
+        data: { subscription: { unsubscribe: mockUnsubscribe } },
+      });
+
+      // Act
+      const { result } = renderHook(() => useSupabaseSession());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Assert
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.session).toBe(null);
+      expect(result.current.token).toBe(null);
+      expect(result.current.error).toBe(mockError);
+      expect(console.error).toHaveBeenCalledWith(
+        "セッション取得エラー:",
+        mockError
+      );
+    });
+
+    it("予期しないエラーが発生した場合、エラー状態を設定する", async () => {
+      // Arrange
+      const mockError = new Error("Unexpected error");
+      mockSupabase.auth.getSession.mockRejectedValue(mockError);
+
+      const mockUnsubscribe = jest.fn();
+      mockSupabase.auth.onAuthStateChange.mockReturnValue({
+        data: { subscription: { unsubscribe: mockUnsubscribe } },
+      });
+
+      // Act
+      const { result } = renderHook(() => useSupabaseSession());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Assert
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.session).toBe(null);
+      expect(result.current.token).toBe(null);
+      expect(result.current.error).toEqual(mockError);
+      expect(console.error).toHaveBeenCalledWith(
+        "予期しないセッション取得エラー:",
+        mockError
+      );
+    });
+
+    it("非Errorオブジェクトがthrowされた場合、適切にエラーハンドリングする", async () => {
+      // Arrange
+      const mockErrorString = "String error";
+      mockSupabase.auth.getSession.mockRejectedValue(mockErrorString);
+
+      const mockUnsubscribe = jest.fn();
+      mockSupabase.auth.onAuthStateChange.mockReturnValue({
+        data: { subscription: { unsubscribe: mockUnsubscribe } },
+      });
+
+      // Act
+      const { result } = renderHook(() => useSupabaseSession());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Assert
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.session).toBe(null);
+      expect(result.current.token).toBe(null);
+      expect(result.current.error).toEqual(
+        new Error("セッション取得に失敗しました")
+      );
+    });
+  });
+
+  describe("セッション自動更新", () => {
+    it("認証状態変更時にセッションを更新し、エラーをクリアする", async () => {
+      // Arrange
+      const mockError = new Error("Initial error");
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: null },
+        error: mockError,
+      });
+
+      let authStateCallback: (
+        event: string,
+        session: unknown
+      ) => void = () => {};
+      const mockUnsubscribe = jest.fn();
+
+      mockSupabase.auth.onAuthStateChange.mockImplementation(
+        (callback: (event: string, session: unknown) => void) => {
+          authStateCallback = callback;
+          return {
+            data: { subscription: { unsubscribe: mockUnsubscribe } },
+          };
+        }
+      );
+
+      // Act
+      const { result } = renderHook(() => useSupabaseSession());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // 初期エラー状態を確認
+      expect(result.current.error).toBe(mockError);
+
+      // 新しいセッションで認証状態変更をシミュレート
+      const newSession = {
+        access_token: "new-token-456",
+        user: { id: "user-456" },
+      };
+
+      act(() => {
+        authStateCallback("SIGNED_IN", newSession);
+      });
+
+      // Assert
+      expect(result.current.session).toBe(newSession);
+      expect(result.current.token).toBe("new-token-456");
+      expect(result.current.error).toBe(null); // エラーがクリアされることを確認
+    });
+
+    it("ログアウト時にセッションをクリアし、エラーもクリアする", async () => {
+      // Arrange
+      const initialSession = {
+        access_token: "initial-token",
+        user: { id: "user-123" },
+      };
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: initialSession },
+        error: null,
+      });
+
+      let authStateCallback: (
+        event: string,
+        session: unknown
+      ) => void = () => {};
+      const mockUnsubscribe = jest.fn();
+
+      mockSupabase.auth.onAuthStateChange.mockImplementation(
+        (callback: (event: string, session: unknown) => void) => {
+          authStateCallback = callback;
+          return {
+            data: { subscription: { unsubscribe: mockUnsubscribe } },
+          };
+        }
+      );
+
+      // Act
+      const { result } = renderHook(() => useSupabaseSession());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // ログアウトをシミュレート
+      act(() => {
+        authStateCallback("SIGNED_OUT", null);
+      });
+
+      // Assert
+      expect(result.current.session).toBe(null);
+      expect(result.current.token).toBe(null);
+      expect(result.current.error).toBe(null);
+    });
+  });
+
+  describe("ページ遷移時の動作", () => {
+    it("パスが変更された場合にセッションを再取得し、エラーをリセットする", async () => {
+      // Arrange
+      const mockSession = {
+        access_token: "test-token",
+        user: { id: "user-123" },
+      };
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: mockSession },
+        error: null,
+      });
+
+      const mockUnsubscribe = jest.fn();
+      mockSupabase.auth.onAuthStateChange.mockReturnValue({
+        data: { subscription: { unsubscribe: mockUnsubscribe } },
+      });
+
+      // Act
+      const { result, rerender } = renderHook(() => useSupabaseSession());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // パスが変更された場合の動作をテスト
+      mockUsePathname.mockReturnValue("/new-path");
+      rerender();
+
+      // Assert: getSessionが再度呼ばれることを確認
+      expect(mockSupabase.auth.getSession).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("クリーンアップ", () => {
+    it("コンポーネントアンマウント時にサブスクリプションを解除する", async () => {
+      // Arrange
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: null },
+        error: null,
+      });
+
+      const mockUnsubscribe = jest.fn();
+      mockSupabase.auth.onAuthStateChange.mockReturnValue({
+        data: { subscription: { unsubscribe: mockUnsubscribe } },
+      });
+
+      // Act
+      const { unmount } = renderHook(() => useSupabaseSession());
+
+      await waitFor(() => {
+        expect(mockSupabase.auth.onAuthStateChange).toHaveBeenCalled();
+      });
+      unmount();
+
+      // Assert
+      expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/app/_hooks/useSupabaseSession.ts
+++ b/src/app/_hooks/useSupabaseSession.ts
@@ -9,26 +9,63 @@ import { useState, useEffect } from "react";
  * - session: 認証セッション (undefined: ローディング中, null: 未ログイン, Session: ログイン済み)
  * - isLoading: ローディング状態
  * - token: アクセストークン
+ * - error: エラー情報
  */
 export const useSupabaseSession = () => {
   const [session, setSession] = useState<Session | null | undefined>(undefined);
   const [token, setToken] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
   const pathname = usePathname();
 
   useEffect(() => {
     const fetcher = async () => {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-      setSession(session);
-      setToken(session?.access_token || null);
-      setIsLoading(false);
+      try {
+        setError(null); // エラー状態をリセット
+        const {
+          data: { session },
+          error: sessionError,
+        } = await supabase.auth.getSession();
+
+        if (sessionError) {
+          console.error("セッション取得エラー:", sessionError);
+          setError(sessionError);
+          setSession(null);
+          setToken(null);
+        } else {
+          setSession(session);
+          setToken(session?.access_token || null);
+        }
+      } catch (error) {
+        console.error("予期しないセッション取得エラー:", error);
+        const errorInstance =
+          error instanceof Error
+            ? error
+            : new Error("セッション取得に失敗しました");
+        setError(errorInstance);
+        setSession(null);
+        setToken(null);
+      } finally {
+        setIsLoading(false);
+      }
     };
 
     fetcher();
     // ページ遷移時にセッション状態を再検証
   }, [pathname]);
 
-  return { session, isLoading, token };
+  // セッション自動更新の監視
+  useEffect(() => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      setSession(session);
+      setToken(session?.access_token || null);
+      setError(null); // セッション更新時にエラーをクリア
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  return { session, isLoading, token, error };
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Pomodoroログ作成時の認証エラー発生時に自動で再認証・リトライを実施し、再度失敗した場合は再ログインを促すエラーを表示するようになりました。
  * Supabaseセッション管理フックでエラー状態を返すようになり、認証状態の変化にも自動対応するよう改善されました。

* **バグ修正**
  * Pomodoroログ作成時やセッション取得時にエラーが発生した場合、ユーザーに分かりやすいエラーメッセージやトースト通知を表示するようになりました。
  * Pomodoro完了モーダルでログ保存失敗時にトースト通知でエラーを案内し、成功時のみアニメーションを表示するよう改善されました。
  * 長休憩フェーズ終了時のログ作成処理にエラーハンドリングとユーザー通知を追加しました。

* **テスト**
  * Pomodoroログ作成機能およびSupabaseセッション管理フックの包括的な単体テストが追加され、各種エラーケースや認証フローが検証されています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->