### PR TITLE
ポモドーロログ保存処理修正とCI整備

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+# 実行タイミング
+on:
+  push:
+    branches: [main, develop] # mainとdevelopブランチへのpush時
+  pull_request:
+    branches: [main, develop] # mainとdevelopへのPR作成・更新時
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      # リポジトリのコードをチェックアウト
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Node.js環境のセットアップ
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      # 依存関係のインストール
+      - name: Install dependencies
+        run: npm ci
+
+      # テスト実行
+      - name: Run tests
+        run: npm test -- --passWithNoTests --coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,14 +36,6 @@ jobs:
       - name: Run ESLint
         run: npm run lint
 
-      # ビルドテスト
-      - name: Build project
-        env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-        run: npm run build
-
       # テスト実行
       - name: Run tests
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,18 @@ jobs:
 
       # ビルドテスト
       - name: Build project
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: npm run build
 
       # テスト実行
       - name: Run tests
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: npm test -- --coverage
 
       # カバレッジレポートをPRにコメント

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,20 @@
 name: Test
 
-# 実行タイミング
 on:
   push:
-    branches: [main, develop] # mainとdevelopブランチへのpush時
+    branches: [main, develop]
   pull_request:
-    branches: [main, develop] # mainとdevelopへのPR作成・更新時
+    branches: [main, develop]
+
+# 基本的な権限設定
+permissions:
+  contents: read
+  pull-requests: write # PRコメント用（カバレッジレポート）
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       # リポジトリのコードをチェックアウト
@@ -27,6 +32,22 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # リントチェック
+      - name: Run ESLint
+        run: npm run lint
+
+      # ビルドテスト
+      - name: Build project
+        run: npm run build
+
       # テスト実行
       - name: Run tests
-        run: npm test -- --passWithNoTests --coverage
+        run: npm test -- --coverage
+
+      # カバレッジレポートをPRにコメント
+      - name: Coverage Report
+        if: github.event_name == 'pull_request'
+        uses: romeovs/lcov-reporter-action@v0.3.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          lcov-file: ./coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -98,7 +98,22 @@ npm install
 ```
 
 3. 環境変数を設定:
-   `.env`ファイルを作成し、変数を設定（具体的な値は管理者にお問い合わせください）
+
+   `.env.local`ファイルを作成し、以下の環境変数を設定してください：
+
+   ```bash
+   # Supabase設定
+   NEXT_PUBLIC_SUPABASE_URL=your_supabase_url_here
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key_here
+
+   # データベース設定
+   DATABASE_URL=your_database_url_here
+   ```
+
+   **注意**: これらの値はSupabaseプロジェクトの設定から取得できます。
+   - Supabase URL: プロジェクト設定 > API > Project URL
+   - Supabase Anon Key: プロジェクト設定 > API > Project API keys > anon public
+   - Database URL: プロジェクト設定 > Database > Connection string > URI
 
 4. 開発サーバーを起動:
 
@@ -107,3 +122,16 @@ npm run dev
 ```
 
 5. ブラウザで http://localhost:3000 を開いてアプリにアクセス
+
+### GitHub Actions設定
+
+CI/CDパイプラインを正常に動作させるために、GitHub Secretsに以下の環境変数を設定してください：
+
+1. GitHubリポジトリの設定ページに移動
+2. Settings > Secrets and variables > Actions
+3. 以下のSecretsを追加：
+   - `NEXT_PUBLIC_SUPABASE_URL`: SupabaseプロジェクトのURL
+   - `NEXT_PUBLIC_SUPABASE_ANON_KEY`: Supabaseの匿名キー
+   - `DATABASE_URL`: データベース接続文字列
+
+これらの値は開発環境で使用するものと同じです。

--- a/src/app/(protected)/timer/_components/PomodoroCompletionModal.tsx
+++ b/src/app/(protected)/timer/_components/PomodoroCompletionModal.tsx
@@ -29,14 +29,20 @@ export const PomodoroCompletionModal: React.FC<Props> = ({
 
   const onSubmitPomodoroLogModal = async (displayInTimeline: boolean) => {
     setIsPomodoroCompletionModalOpen(false);
-    await createPomodoroLog({
-      completedCount: storedSettings.cycles,
-      completedTime: storedSettings.focusTime,
-      displayInTimeline,
-      categoryIds,
-      token: token ?? "",
-    });
-    Confetti();
+    try {
+      await createPomodoroLog({
+        completedCount: storedSettings.cycles,
+        completedTime: storedSettings.focusTime,
+        displayInTimeline,
+        categoryIds,
+        token: token ?? "",
+      });
+      Confetti();
+    } catch (error) {
+      console.error("ポモドーロログの保存に失敗:", error);
+      // エラー時は通知のみで、Confettiは実行しない
+      alert("データ保存に失敗しました。インターネット接続を確認してください。");
+    }
   };
 
   // プレビュー用のログデータ

--- a/src/app/(protected)/timer/_components/PomodoroCompletionModal.tsx
+++ b/src/app/(protected)/timer/_components/PomodoroCompletionModal.tsx
@@ -7,6 +7,7 @@ import { createPomodoroLog } from "../_lib/createPomodoroLog";
 import { TimerSettings } from "@/app/_config/timerConfig";
 import { Confetti } from "./Confetti";
 import { PomodoroLogType } from "@/app/_types/pomodoro";
+import { toast } from "react-toastify";
 
 interface Props {
   storedSettings: TimerSettings;
@@ -41,7 +42,9 @@ export const PomodoroCompletionModal: React.FC<Props> = ({
     } catch (error) {
       console.error("ポモドーロログの保存に失敗:", error);
       // エラー時は通知のみで、Confettiは実行しない
-      alert("データ保存に失敗しました。インターネット接続を確認してください。");
+      toast.error(
+        "データ保存に失敗しました。インターネット接続を確認してください。"
+      );
     }
   };
 

--- a/src/app/(protected)/timer/_lib/createPomodoroLog.test.ts
+++ b/src/app/(protected)/timer/_lib/createPomodoroLog.test.ts
@@ -1,0 +1,323 @@
+import { createPomodoroLog } from "./createPomodoroLog";
+import { fetcher } from "@/app/_utils/fetcher";
+import { supabase } from "@/app/_utils/supabase";
+
+// fetcherとsupabaseをモック化
+jest.mock("@/app/_utils/fetcher");
+jest.mock("@/app/_utils/supabase", () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn(),
+    },
+  },
+}));
+
+const mockFetcher = fetcher as jest.MockedFunction<typeof fetcher>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockSupabase = supabase as any;
+
+describe("createPomodoroLog", () => {
+  const mockParams = {
+    completedCount: 4,
+    completedTime: 25,
+    displayInTimeline: true,
+    categoryIds: ["category-1", "category-2"],
+    token: "test-token-123",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // console.errorとconsole.logをモック化してテスト出力をクリーンに保つ
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("正常系", () => {
+    it("正常にポモドーロログを作成できる", async () => {
+      // Arrange
+      const mockResponse = {
+        status: "success",
+        message: "ポモドーロログを作成しました",
+        data: { id: "log-123" },
+      };
+
+      mockFetcher.mockResolvedValue(mockResponse);
+
+      // Act
+      await createPomodoroLog(mockParams);
+
+      // Assert: fetcherが正しいパラメータで呼ばれることを確認
+      expect(mockFetcher).toHaveBeenCalledWith({
+        apiPath: "/api/pomodoro",
+        method: "POST",
+        body: {
+          completedCount: 4,
+          completedTime: 25,
+          displayInTimeline: true,
+          categoryIds: ["category-1", "category-2"],
+        },
+        token: "test-token-123",
+      });
+      expect(mockFetcher).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("異常系 - リトライなし", () => {
+    it("ネットワークエラー時は即座に例外を投げる", async () => {
+      // Arrange
+      const networkError = new Error("Network error");
+      mockFetcher.mockRejectedValue(networkError);
+
+      // Act & Assert
+      await expect(createPomodoroLog(mockParams)).rejects.toThrow(
+        "Network error"
+      );
+
+      expect(mockFetcher).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledWith(
+        "ポモドーロログの作成に失敗しました",
+        networkError
+      );
+    });
+
+    it("バリデーションエラー時は即座に例外を投げる", async () => {
+      // Arrange
+      const validationError = new Error("Validation failed");
+      mockFetcher.mockRejectedValue(validationError);
+
+      // Act & Assert
+      await expect(createPomodoroLog(mockParams)).rejects.toThrow(
+        "Validation failed"
+      );
+
+      expect(mockFetcher).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("異常系 - 認証エラーリトライ", () => {
+    it("認証エラー時にリトライして成功する", async () => {
+      // Arrange
+      const authError = new Error("認証に失敗しました");
+      const mockNewSession = {
+        access_token: "new-token-456",
+        user: { id: "user-123" },
+      };
+
+      // 1回目は認証エラー、2回目は成功
+      mockFetcher
+        .mockRejectedValueOnce(authError)
+        .mockResolvedValueOnce({ status: "success" });
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: mockNewSession },
+        error: null,
+      });
+
+      // Act
+      await createPomodoroLog(mockParams);
+
+      // Assert: 2回fetcherが呼ばれることを確認
+      expect(mockFetcher).toHaveBeenCalledTimes(2);
+
+      // 1回目の呼び出し（失敗）
+      expect(mockFetcher).toHaveBeenNthCalledWith(1, {
+        apiPath: "/api/pomodoro",
+        method: "POST",
+        body: {
+          completedCount: 4,
+          completedTime: 25,
+          displayInTimeline: true,
+          categoryIds: ["category-1", "category-2"],
+        },
+        token: "test-token-123",
+      });
+
+      // 2回目の呼び出し（成功、新しいトークンを使用）
+      expect(mockFetcher).toHaveBeenNthCalledWith(2, {
+        apiPath: "/api/pomodoro",
+        method: "POST",
+        body: {
+          completedCount: 4,
+          completedTime: 25,
+          displayInTimeline: true,
+          categoryIds: ["category-1", "category-2"],
+        },
+        token: "new-token-456",
+      });
+
+      // 開発環境でのみconsole.logが実行されることを確認
+      if (process.env.NODE_ENV === "development") {
+        expect(console.log).toHaveBeenCalledWith(
+          "認証エラーを検出。セッションを更新してリトライします..."
+        );
+        expect(console.log).toHaveBeenCalledWith(
+          "リトライによりポモドーロログの作成に成功しました"
+        );
+      } else {
+        expect(console.log).not.toHaveBeenCalled();
+      }
+    });
+
+    it("unauthorizedエラー時にリトライして成功する", async () => {
+      // Arrange
+      const authError = new Error("unauthorized access");
+      const mockNewSession = {
+        access_token: "new-token-789",
+        user: { id: "user-456" },
+      };
+
+      mockFetcher
+        .mockRejectedValueOnce(authError)
+        .mockResolvedValueOnce({ status: "success" });
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: mockNewSession },
+        error: null,
+      });
+
+      // Act
+      await createPomodoroLog(mockParams);
+
+      // Assert
+      expect(mockFetcher).toHaveBeenCalledTimes(2);
+      expect(mockFetcher).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          token: "new-token-789",
+        })
+      );
+    });
+
+    it("401エラー時にリトライして成功する", async () => {
+      // Arrange
+      const authError = new Error("401 authentication failed");
+      const mockNewSession = {
+        access_token: "refreshed-token-abc",
+        user: { id: "user-789" },
+      };
+
+      mockFetcher
+        .mockRejectedValueOnce(authError)
+        .mockResolvedValueOnce({ status: "success" });
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: mockNewSession },
+        error: null,
+      });
+
+      // Act
+      await createPomodoroLog(mockParams);
+
+      // Assert
+      expect(mockFetcher).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("異常系 - リトライも失敗", () => {
+    it("セッション更新に失敗した場合", async () => {
+      // Arrange
+      const authError = new Error("認証に失敗しました");
+      mockFetcher.mockRejectedValue(authError);
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: null },
+        error: null,
+      });
+
+      // Act & Assert
+      await expect(createPomodoroLog(mockParams)).rejects.toThrow(
+        "認証エラー: ログインし直してください"
+      );
+
+      expect(mockFetcher).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledWith(
+        "リトライも失敗しました",
+        expect.any(Error)
+      );
+    });
+
+    it("セッション取得時にエラーが発生した場合", async () => {
+      // Arrange
+      const authError = new Error("unauthorized");
+      mockFetcher.mockRejectedValue(authError);
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: null },
+        error: new Error("Session fetch failed"),
+      });
+
+      // Act & Assert
+      await expect(createPomodoroLog(mockParams)).rejects.toThrow(
+        "認証エラー: ログインし直してください"
+      );
+    });
+
+    it("リトライ後も認証エラーが続く場合", async () => {
+      // Arrange
+      const authError = new Error("認証失敗");
+      const retryError = new Error("リトライでも認証失敗");
+
+      mockFetcher
+        .mockRejectedValueOnce(authError)
+        .mockRejectedValueOnce(retryError);
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: { access_token: "valid-token" } },
+        error: null,
+      });
+
+      // Act & Assert
+      await expect(createPomodoroLog(mockParams)).rejects.toThrow(
+        "認証エラー: ログインし直してください"
+      );
+
+      expect(mockFetcher).toHaveBeenCalledTimes(2);
+      expect(console.error).toHaveBeenCalledWith(
+        "リトライも失敗しました",
+        retryError
+      );
+    });
+  });
+
+  describe("境界値テスト", () => {
+    it("空のカテゴリIDでも正常に動作する", async () => {
+      // Arrange
+      const paramsWithEmptyCategories = {
+        ...mockParams,
+        categoryIds: [],
+      };
+
+      mockFetcher.mockResolvedValue({ status: "success" });
+
+      // Act
+      await createPomodoroLog(paramsWithEmptyCategories);
+
+      // Assert
+      expect(mockFetcher).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            categoryIds: [],
+          }),
+        })
+      );
+    });
+
+    it("空のトークンでも正常にエラーハンドリングが動作する", async () => {
+      // Arrange
+      const paramsWithEmptyToken = {
+        ...mockParams,
+        token: "",
+      };
+
+      const authError = new Error("認証が必要です");
+      mockFetcher.mockRejectedValue(authError);
+
+      // Act & Assert
+      await expect(createPomodoroLog(paramsWithEmptyToken)).rejects.toThrow();
+    });
+  });
+});

--- a/src/app/(protected)/timer/_lib/createPomodoroLog.ts
+++ b/src/app/(protected)/timer/_lib/createPomodoroLog.ts
@@ -1,4 +1,5 @@
 import { fetcher } from "@/app/_utils/fetcher";
+import { supabase } from "@/app/_utils/supabase";
 
 interface Props {
   completedCount: number;
@@ -29,6 +30,54 @@ export const createPomodoroLog = async ({
     });
   } catch (error) {
     console.error("ポモドーロログの作成に失敗しました", error);
+
+    // 認証エラーの場合はリトライを試行
+    if (
+      error instanceof Error &&
+      (error.message.includes("認証") ||
+        error.message.includes("unauthorized") ||
+        error.message.includes("401"))
+    ) {
+      try {
+        if (process.env.NODE_ENV === "development") {
+          console.log(
+            "認証エラーを検出。セッションを更新してリトライします..."
+          );
+        }
+
+        // 最新のセッションを取得
+        const {
+          data: { session },
+          error: sessionError,
+        } = await supabase.auth.getSession();
+
+        if (sessionError || !session?.access_token) {
+          throw new Error("セッションの更新に失敗しました");
+        }
+
+        // 新しいトークンでリトライ
+        await fetcher({
+          apiPath: "/api/pomodoro",
+          method: "POST",
+          body: {
+            completedCount,
+            completedTime,
+            displayInTimeline,
+            categoryIds,
+          },
+          token: session.access_token,
+        });
+
+        if (process.env.NODE_ENV === "development") {
+          console.log("リトライによりポモドーロログの作成に成功しました");
+        }
+        return;
+      } catch (retryError) {
+        console.error("リトライも失敗しました", retryError);
+        throw new Error("認証エラー: ログインし直してください");
+      }
+    }
+
     throw error;
   }
 };

--- a/src/app/(protected)/timer/page.tsx
+++ b/src/app/(protected)/timer/page.tsx
@@ -124,13 +124,19 @@ export default function Page() {
       if (postButtonToTimeline) {
         setIsPomodoroCompletionModalOpen(true);
       } else {
-        await createPomodoroLog({
-          completedCount: storedSettings.cycles,
-          completedTime: storedSettings.focusTime,
-          displayInTimeline: false,
-          categoryIds,
-          token: token ?? "",
-        });
+        try {
+          await createPomodoroLog({
+            completedCount: storedSettings.cycles,
+            completedTime: storedSettings.focusTime,
+            displayInTimeline: false,
+            categoryIds,
+            token: token ?? "",
+          });
+          toast.success("ポモドーロが正常に記録されました！");
+        } catch (error) {
+          console.error("ポモドーロログの保存に失敗:", error);
+          toast.error("データ保存に失敗しました。インターネット接続を確認してください。");
+        }
       }
       if (setRandomTime) {
         // ランダムな設定をセット

--- a/src/app/(protected)/timer/page.tsx
+++ b/src/app/(protected)/timer/page.tsx
@@ -125,17 +125,23 @@ export default function Page() {
         setIsPomodoroCompletionModalOpen(true);
       } else {
         try {
+          if (!token) {
+            toast.error("認証情報がありません。再度ログインしてください。");
+            return;
+          }
           await createPomodoroLog({
             completedCount: storedSettings.cycles,
             completedTime: storedSettings.focusTime,
             displayInTimeline: false,
             categoryIds,
-            token: token ?? "",
+            token,
           });
           toast.success("ポモドーロが正常に記録されました！");
         } catch (error) {
           console.error("ポモドーロログの保存に失敗:", error);
-          toast.error("データ保存に失敗しました。インターネット接続を確認してください。");
+          toast.error(
+            "データ保存に失敗しました。インターネット接続を確認してください。"
+          );
         }
       }
       if (setRandomTime) {

--- a/src/app/_hooks/useSupabaseSession.test.ts
+++ b/src/app/_hooks/useSupabaseSession.test.ts
@@ -1,0 +1,342 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useSupabaseSession } from "./useSupabaseSession";
+import { supabase } from "@/app/_utils/supabase";
+import { usePathname } from "next/navigation";
+
+// Next.jsとSupabaseをモック化
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(),
+}));
+
+jest.mock("@/app/_utils/supabase", () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn(),
+      onAuthStateChange: jest.fn(),
+    },
+  },
+}));
+
+const mockUsePathname = usePathname as jest.MockedFunction<typeof usePathname>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockSupabase = supabase as any;
+
+describe("useSupabaseSession", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePathname.mockReturnValue("/test");
+    // console.errorをモック化してテスト出力をクリーンに保つ
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("初期セッション取得", () => {
+    it("セッションが存在する場合、正しく状態を設定する", async () => {
+      // Arrange: モックセッションデータを準備
+      const mockSession = {
+        access_token: "test-token-123",
+        user: { id: "user-123" },
+      };
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: mockSession },
+        error: null,
+      });
+
+      const mockUnsubscribe = jest.fn();
+      mockSupabase.auth.onAuthStateChange.mockReturnValue({
+        data: { subscription: { unsubscribe: mockUnsubscribe } },
+      });
+
+      // Act: フックを実行
+      const { result } = renderHook(() => useSupabaseSession());
+
+      // 初期状態の確認
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.session).toBe(undefined);
+      expect(result.current.token).toBe(null);
+      expect(result.current.error).toBe(null);
+
+      // セッション取得完了まで待機
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Assert: 期待する結果と比較
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.session).toBe(mockSession);
+      expect(result.current.token).toBe("test-token-123");
+      expect(result.current.error).toBe(null);
+    });
+
+    it("セッションが存在しない場合、null状態を設定する", async () => {
+      // Arrange
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: null },
+        error: null,
+      });
+
+      const mockUnsubscribe = jest.fn();
+      mockSupabase.auth.onAuthStateChange.mockReturnValue({
+        data: { subscription: { unsubscribe: mockUnsubscribe } },
+      });
+
+      // Act
+      const { result } = renderHook(() => useSupabaseSession());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Assert
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.session).toBe(null);
+      expect(result.current.token).toBe(null);
+      expect(result.current.error).toBe(null);
+    });
+
+    it("セッション取得時にSupabaseエラーが発生した場合、エラー状態を設定する", async () => {
+      // Arrange
+      const mockError = new Error("Supabase session error");
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: null },
+        error: mockError,
+      });
+
+      const mockUnsubscribe = jest.fn();
+      mockSupabase.auth.onAuthStateChange.mockReturnValue({
+        data: { subscription: { unsubscribe: mockUnsubscribe } },
+      });
+
+      // Act
+      const { result } = renderHook(() => useSupabaseSession());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Assert
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.session).toBe(null);
+      expect(result.current.token).toBe(null);
+      expect(result.current.error).toBe(mockError);
+      expect(console.error).toHaveBeenCalledWith(
+        "セッション取得エラー:",
+        mockError
+      );
+    });
+
+    it("予期しないエラーが発生した場合、エラー状態を設定する", async () => {
+      // Arrange
+      const mockError = new Error("Unexpected error");
+      mockSupabase.auth.getSession.mockRejectedValue(mockError);
+
+      const mockUnsubscribe = jest.fn();
+      mockSupabase.auth.onAuthStateChange.mockReturnValue({
+        data: { subscription: { unsubscribe: mockUnsubscribe } },
+      });
+
+      // Act
+      const { result } = renderHook(() => useSupabaseSession());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Assert
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.session).toBe(null);
+      expect(result.current.token).toBe(null);
+      expect(result.current.error).toEqual(mockError);
+      expect(console.error).toHaveBeenCalledWith(
+        "予期しないセッション取得エラー:",
+        mockError
+      );
+    });
+
+    it("非Errorオブジェクトがthrowされた場合、適切にエラーハンドリングする", async () => {
+      // Arrange
+      const mockErrorString = "String error";
+      mockSupabase.auth.getSession.mockRejectedValue(mockErrorString);
+
+      const mockUnsubscribe = jest.fn();
+      mockSupabase.auth.onAuthStateChange.mockReturnValue({
+        data: { subscription: { unsubscribe: mockUnsubscribe } },
+      });
+
+      // Act
+      const { result } = renderHook(() => useSupabaseSession());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Assert
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.session).toBe(null);
+      expect(result.current.token).toBe(null);
+      expect(result.current.error).toEqual(
+        new Error("セッション取得に失敗しました")
+      );
+    });
+  });
+
+  describe("セッション自動更新", () => {
+    it("認証状態変更時にセッションを更新し、エラーをクリアする", async () => {
+      // Arrange
+      const mockError = new Error("Initial error");
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: null },
+        error: mockError,
+      });
+
+      let authStateCallback: (
+        event: string,
+        session: unknown
+      ) => void = () => {};
+      const mockUnsubscribe = jest.fn();
+
+      mockSupabase.auth.onAuthStateChange.mockImplementation(
+        (callback: (event: string, session: unknown) => void) => {
+          authStateCallback = callback;
+          return {
+            data: { subscription: { unsubscribe: mockUnsubscribe } },
+          };
+        }
+      );
+
+      // Act
+      const { result } = renderHook(() => useSupabaseSession());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // 初期エラー状態を確認
+      expect(result.current.error).toBe(mockError);
+
+      // 新しいセッションで認証状態変更をシミュレート
+      const newSession = {
+        access_token: "new-token-456",
+        user: { id: "user-456" },
+      };
+
+      act(() => {
+        authStateCallback("SIGNED_IN", newSession);
+      });
+
+      // Assert
+      expect(result.current.session).toBe(newSession);
+      expect(result.current.token).toBe("new-token-456");
+      expect(result.current.error).toBe(null); // エラーがクリアされることを確認
+    });
+
+    it("ログアウト時にセッションをクリアし、エラーもクリアする", async () => {
+      // Arrange
+      const initialSession = {
+        access_token: "initial-token",
+        user: { id: "user-123" },
+      };
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: initialSession },
+        error: null,
+      });
+
+      let authStateCallback: (
+        event: string,
+        session: unknown
+      ) => void = () => {};
+      const mockUnsubscribe = jest.fn();
+
+      mockSupabase.auth.onAuthStateChange.mockImplementation(
+        (callback: (event: string, session: unknown) => void) => {
+          authStateCallback = callback;
+          return {
+            data: { subscription: { unsubscribe: mockUnsubscribe } },
+          };
+        }
+      );
+
+      // Act
+      const { result } = renderHook(() => useSupabaseSession());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // ログアウトをシミュレート
+      act(() => {
+        authStateCallback("SIGNED_OUT", null);
+      });
+
+      // Assert
+      expect(result.current.session).toBe(null);
+      expect(result.current.token).toBe(null);
+      expect(result.current.error).toBe(null);
+    });
+  });
+
+  describe("ページ遷移時の動作", () => {
+    it("パスが変更された場合にセッションを再取得し、エラーをリセットする", async () => {
+      // Arrange
+      const mockSession = {
+        access_token: "test-token",
+        user: { id: "user-123" },
+      };
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: mockSession },
+        error: null,
+      });
+
+      const mockUnsubscribe = jest.fn();
+      mockSupabase.auth.onAuthStateChange.mockReturnValue({
+        data: { subscription: { unsubscribe: mockUnsubscribe } },
+      });
+
+      // Act
+      const { result, rerender } = renderHook(() => useSupabaseSession());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // パスが変更された場合の動作をテスト
+      mockUsePathname.mockReturnValue("/new-path");
+      rerender();
+
+      // Assert: getSessionが再度呼ばれることを確認
+      expect(mockSupabase.auth.getSession).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("クリーンアップ", () => {
+    it("コンポーネントアンマウント時にサブスクリプションを解除する", async () => {
+      // Arrange
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: null },
+        error: null,
+      });
+
+      const mockUnsubscribe = jest.fn();
+      mockSupabase.auth.onAuthStateChange.mockReturnValue({
+        data: { subscription: { unsubscribe: mockUnsubscribe } },
+      });
+
+      // Act
+      const { unmount } = renderHook(() => useSupabaseSession());
+
+      await waitFor(() => {
+        expect(mockSupabase.auth.onAuthStateChange).toHaveBeenCalled();
+      });
+      unmount();
+
+      // Assert
+      expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/app/_hooks/useSupabaseSession.ts
+++ b/src/app/_hooks/useSupabaseSession.ts
@@ -9,26 +9,63 @@ import { useState, useEffect } from "react";
  * - session: 認証セッション (undefined: ローディング中, null: 未ログイン, Session: ログイン済み)
  * - isLoading: ローディング状態
  * - token: アクセストークン
+ * - error: エラー情報
  */
 export const useSupabaseSession = () => {
   const [session, setSession] = useState<Session | null | undefined>(undefined);
   const [token, setToken] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
   const pathname = usePathname();
 
   useEffect(() => {
     const fetcher = async () => {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-      setSession(session);
-      setToken(session?.access_token || null);
-      setIsLoading(false);
+      try {
+        setError(null); // エラー状態をリセット
+        const {
+          data: { session },
+          error: sessionError,
+        } = await supabase.auth.getSession();
+
+        if (sessionError) {
+          console.error("セッション取得エラー:", sessionError);
+          setError(sessionError);
+          setSession(null);
+          setToken(null);
+        } else {
+          setSession(session);
+          setToken(session?.access_token || null);
+        }
+      } catch (error) {
+        console.error("予期しないセッション取得エラー:", error);
+        const errorInstance =
+          error instanceof Error
+            ? error
+            : new Error("セッション取得に失敗しました");
+        setError(errorInstance);
+        setSession(null);
+        setToken(null);
+      } finally {
+        setIsLoading(false);
+      }
     };
 
     fetcher();
     // ページ遷移時にセッション状態を再検証
   }, [pathname]);
 
-  return { session, isLoading, token };
+  // セッション自動更新の監視
+  useEffect(() => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      setSession(session);
+      setToken(session?.access_token || null);
+      setError(null); // セッション更新時にエラーをクリア
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  return { session, isLoading, token, error };
 };

--- a/src/app/_utils/supabase.ts
+++ b/src/app/_utils/supabase.ts
@@ -1,7 +1,18 @@
 /** 環境変数から初期化されるSupabaseクライアント */
 import { createClient } from "@supabase/supabase-js";
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+// 環境変数の存在チェック
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl) {
+  throw new Error("NEXT_PUBLIC_SUPABASE_URL environment variable is required");
+}
+
+if (!supabaseAnonKey) {
+  throw new Error(
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable is required"
+  );
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/app/_utils/supabase.ts
+++ b/src/app/_utils/supabase.ts
@@ -1,18 +1,7 @@
 /** 環境変数から初期化されるSupabaseクライアント */
 import { createClient } from "@supabase/supabase-js";
 
-// 環境変数の存在チェック
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-if (!supabaseUrl) {
-  throw new Error("NEXT_PUBLIC_SUPABASE_URL environment variable is required");
-}
-
-if (!supabaseAnonKey) {
-  throw new Error(
-    "NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable is required"
-  );
-}
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Pomodoroログ作成時に認証エラーが発生した場合、自動でセッショントークンをリフレッシュし再試行するリトライ機能を追加しました。
  * Supabase認証セッション管理用のカスタムフックにエラー状態の管理・返却を追加しました。
  * GitHub Actionsによる自動テスト・カバレッジレポート投稿のCIワークフローを追加しました。

* **バグ修正**
  * Pomodoroログ作成やタイマー完了時にエラーが発生した場合、ユーザーにトースト通知で失敗を知らせるようになりました。

* **ドキュメント**
  * 環境変数やGitHub Actionsの設定方法についてREADMEを詳細化しました。

* **テスト**
  * Pomodoroログ作成処理とSupabaseセッション管理フックの単体テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->